### PR TITLE
feat(backend): add centralized logging with configurable LOG_LEVEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ FRITZBOX_USERNAME=deinuser
 FRITZBOX_PASSWORD=deinpasswort
 POLL_INTERVAL_SECONDS=60
 DEVICE_LOG_POLL_INTERVAL_SECONDS=60
+# Log level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+# LOG_LEVEL=INFO
 OUTAGE_PLANNED_KEYWORDS=zwangstrennung,wird kurz unterbrochen,trennung durch den anbieter
 OUTAGE_IPV4_DISCONNECT_KEYWORDS=internetverbindung wurde getrennt
 OUTAGE_IPV4_CONNECT_KEYWORDS=internetverbindung wurde erfolgreich hergestellt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,18 @@ The backend is organized in a service-oriented architecture:
 - **`backend/outage_config.py`**: Default keywords for planned/unplanned outage detection
 - **`backend/schemas.py`**: Pydantic models for API request/response
 - **`backend/models.py`**: Domain models for database records
+- **`backend/reporting.py`**: `ReportingService` calculates KPIs (availability, MTTR, MTBF) and renders HTML reports via Jinja2 templates
+- **`backend/email_service.py`**: Async SMTP email delivery using `aiosmtplib`, sends reports as HTML attachments
+- **`backend/report_scheduler.py`**: `ReportScheduler` runs periodically (default hourly) and sends the weekly report on Mondays, using `MetadataRepository` to track last-sent week
+- **`backend/templates/weekly_report.html`**: Jinja2 template for the weekly HTML report
 
 **Key Backend Patterns:**
+- Centralized logging configured via `logging.basicConfig()` in `main.py`; all modules use `logging.getLogger(__name__)`
 - Status changes are only recorded when different from latest stored event
 - Device logs are deduplicated using UNIQUE constraint on (log_timestamp, message)
 - Outages table is fully replaced on each sync (simplifies state management)
 - Separate state tracking for IPv4 and IPv6 allows detection of protocol-specific issues
+- `MetadataRepository` stores key-value pairs (e.g., `last_weekly_report_sent_at`) to track scheduler state across restarts
 
 ### Frontend Structure
 
@@ -133,6 +139,7 @@ FRITZBOX_PASSWORD=secret
 POLL_INTERVAL_SECONDS=60
 DEVICE_LOG_POLL_INTERVAL_SECONDS=60
 DATABASE_PATH=data/stoergeler.db
+LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR
 ```
 
 Optional keyword customization (CSV format):
@@ -142,6 +149,20 @@ OUTAGE_IPV4_DISCONNECT_KEYWORDS="PPPoE-Fehler,Zeitüberschreitung"
 OUTAGE_IPV4_CONNECT_KEYWORDS="PPPoE,DSL antwortet"
 OUTAGE_IPV6_DISCONNECT_KEYWORDS="IPv6-Präfix,Präfix verloren"
 OUTAGE_IPV6_CONNECT_KEYWORDS="IPv6-Präfix wurde erfolgreich bezogen"
+```
+
+Optional SMTP/reporting configuration:
+```bash
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=user
+SMTP_PASSWORD=secret
+SMTP_FROM=noreply@stoergeler.local
+SMTP_TLS=True
+SMTP_SSL=False
+REPORT_RECIPIENTS="admin@example.com,ops@example.com"  # CSV list
+REPORT_EMAIL_BODY="Custom body with {week_number}, {start_date}, {end_date} placeholders"
+REPORT_SCHEDULE_CHECK_INTERVAL_SECONDS=3600
 ```
 
 ## Data Flow
@@ -163,7 +184,13 @@ OUTAGE_IPV6_CONNECT_KEYWORDS="IPv6-Präfix wurde erfolgreich bezogen"
    - Classifies as planned/unplanned based on preceding hints
    - Generates "open" outages for unmatched disconnects
 
-4. **Frontend Display**:
+4. **Weekly Email Reports** (report_scheduler.py → reporting.py → email_service.py):
+   - `ReportScheduler` checks hourly if it's Monday and no report has been sent for the current week
+   - Generates KPIs (availability %, MTTR, MTBF, incident counts) for the previous week
+   - Renders HTML report using Jinja2 template, sends as email attachment via `aiosmtplib`
+   - Tracks sent state in `metadata` table to prevent duplicate sends
+
+5. **Frontend Display**:
    - Fetches `/api/outages` and `/api/device-log` on mount and refresh
    - Displays outages in calendar and table views
    - Shows device logs with pagination
@@ -200,10 +227,11 @@ The frontend has mobile-specific behavior:
 
 ## Database Schema
 
-Three tables in SQLite (`data/stoergeler.db`):
+Four tables in SQLite (`data/stoergeler.db`):
 
 1. **status_events**: Connection status changes (online/offline/error)
 2. **device_log_entries**: Raw Fritzbox logs with UNIQUE(log_timestamp, message)
 3. **outages**: Calculated outage intervals (fully replaced on each sync)
+4. **metadata**: Key-value store for scheduler state (e.g., last report sent week)
 
 Foreign keys link outages to start/end log entries for traceability.

--- a/backend/config.py
+++ b/backend/config.py
@@ -48,6 +48,9 @@ class Settings:
         "OUTAGE_IPV6_CONNECT_KEYWORDS", DEFAULT_OUTAGE_KEYWORDS.ipv6_connect_keywords
     )
 
+    # Logging
+    log_level: str = os.getenv("LOG_LEVEL", "INFO")
+
     # SMTP Settings
     smtp_server: str = os.getenv("SMTP_SERVER", "")
     smtp_port: int = int(os.getenv("SMTP_PORT", "587"))

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
@@ -7,6 +8,8 @@ from pathlib import Path
 from typing import Any, Generator, Iterable, List, Optional, Sequence
 
 from .models import DeviceLogEntryRecord, OutageRecord, StatusEvent
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseContext:
@@ -26,6 +29,7 @@ class DatabaseContext:
             conn.close()
 
     def init_schema(self) -> None:
+        logger.info("Initializing database schema at %s", self._database_path)
         with self.connect() as conn:
             conn.execute(
                 """

--- a/backend/device_log_sync.py
+++ b/backend/device_log_sync.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Iterable
 
 from .database import DeviceLogRepository, OutageRepository
 from .fritzbox_client import FritzboxClient
 from .outage_calculator import OutageCalculator
+
+logger = logging.getLogger(__name__)
 
 
 class DeviceLogSync:
@@ -23,8 +26,13 @@ class DeviceLogSync:
         self._outage_calculator = outage_calculator
 
     def run_once(self) -> None:
-        entries: Iterable[Dict[str, Any]] = self._fritzbox_client.fetch_device_log()
-        self._device_log_repository.ingest_entries(entries)
+        entries = list(self._fritzbox_client.fetch_device_log())
+        new_count = self._device_log_repository.ingest_entries(entries)
         stored_entries = self._device_log_repository.list_entries()
         outages = self._outage_calculator.calculate(stored_entries)
         self._outage_repository.replace_outages(outages)
+        logger.info(
+            "Device log sync: %d new entries ingested, %d outages calculated",
+            new_count,
+            len(outages),
+        )

--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -64,7 +64,10 @@ class EmailService:
                     )
                 await smtp.send_message(message)
                 
-            logger.info(f"Report email with attachment sent to {len(target_recipients)} recipients.")
+            logger.info(
+                "Report email sent to %d recipients, subject=%r, body_preview=%r",
+                len(target_recipients), subject, body_text[:80],
+            )
         except Exception as exc:
             logger.error(f"Failed to send report email: {exc}")
             raise

--- a/backend/fritzbox_client.py
+++ b/backend/fritzbox_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -7,6 +8,8 @@ from typing import Any, Dict, List, Optional
 
 from fritzconnection import FritzConnection
 from fritzconnection.lib.fritzstatus import FritzStatus
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -65,15 +68,23 @@ class FritzboxClient:
         }
 
     def poll_status(self) -> Dict[str, Any]:
-        client = self._create_status_client()
-        return {
-            "connected": bool(getattr(client, "is_connected", False)),
-            "details": self._collect_details(client),
-        }
+        try:
+            client = self._create_status_client()
+            return {
+                "connected": bool(getattr(client, "is_connected", False)),
+                "details": self._collect_details(client),
+            }
+        except Exception:
+            logger.error("TR-064 connection error during status poll", exc_info=True)
+            raise
 
     def fetch_device_log(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
-        connection = self._create_connection()
-        result = connection.call_action("DeviceInfo:1", "GetDeviceLog")
+        try:
+            connection = self._create_connection()
+            result = connection.call_action("DeviceInfo:1", "GetDeviceLog")
+        except Exception:
+            logger.error("TR-064 connection error during device log fetch", exc_info=True)
+            raise
         log_blob = result.get("NewDeviceLog", "") if isinstance(result, dict) else ""
         entries: List[Dict[str, Any]] = []
         for line in log_blob.splitlines():
@@ -83,7 +94,8 @@ class FritzboxClient:
             parsed = self._parse_log_line(cleaned)
             entries.append(parsed)
         if limit is not None:
-            return entries[:limit]
+            entries = entries[:limit]
+        logger.debug("Fetched %d device log entries", len(entries))
         return entries
 
     def _parse_log_line(self, line: str) -> Dict[str, Any]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
+import logging
 from typing import Dict, Optional
 import os
+
+from .config import settings
+
+# --- Logging setup (before any other module creates loggers) ---
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    level=getattr(logging, settings.log_level.upper(), logging.INFO),
+)
+# Quiet noisy third-party loggers
+for _name in ("httpcore", "httpx", "fritzconnection", "urllib3"):
+    logging.getLogger(_name).setLevel(logging.WARNING)
+
+logger = logging.getLogger(__name__)
 
 from fastapi import FastAPI, HTTPException, Query
 from starlette.status import HTTP_201_CREATED
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
-
-from .config import settings
 from .database import (
     DatabaseContext,
     DeviceLogRepository,
@@ -96,12 +108,15 @@ report_scheduler = ReportScheduler(
 
 @app.on_event("startup")
 async def _startup() -> None:
+    logger.info("StoerGeler backend starting up")
     await tracker.start()
     await report_scheduler.start()
+    logger.info("StoerGeler backend started")
 
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
+    logger.info("StoerGeler backend shutting down")
     await tracker.stop()
     await report_scheduler.stop()
 

--- a/backend/periodic_runner.py
+++ b/backend/periodic_runner.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from typing import Any, Awaitable, Callable, Optional, Union
+
+logger = logging.getLogger(__name__)
 
 
 class PeriodicRunner:
@@ -27,6 +30,7 @@ class PeriodicRunner:
             return
         self._stop_event.clear()
         self._task = asyncio.create_task(self._run())
+        logger.debug("PeriodicRunner started (interval=%ds)", self._interval)
 
     async def stop(self) -> None:
         if self._task is None:
@@ -34,6 +38,7 @@ class PeriodicRunner:
         self._stop_event.set()
         await self._task
         self._task = None
+        logger.debug("PeriodicRunner stopped")
 
     async def _run(self) -> None:
         while not self._stop_event.is_set():
@@ -44,6 +49,7 @@ class PeriodicRunner:
                     loop = asyncio.get_running_loop()
                     await loop.run_in_executor(None, self._work)
             except Exception as exc:  # noqa: BLE001
+                logger.error("PeriodicRunner task failed: %s", exc, exc_info=True)
                 if self._on_error is not None:
                     self._on_error(exc)
 

--- a/backend/report_scheduler.py
+++ b/backend/report_scheduler.py
@@ -50,12 +50,13 @@ class ReportScheduler:
 
         last_sent_iso = self._metadata_repo.get("last_weekly_report_sent_at")
         current_week_key = f"{now.year}-W{now.isocalendar()[1]}"
-        
+        logger.debug("Report guard check: last_sent=%s, current_week=%s", last_sent_iso, current_week_key)
+
         if last_sent_iso == current_week_key:
-            logger.debug(f"Weekly report for {current_week_key} already sent.")
+            logger.debug("Weekly report for %s already sent, skipping.", current_week_key)
             return
 
-        logger.info(f"It's Monday! Preparing weekly report for {current_week_key}...")
+        logger.info("Preparing weekly report for %s ...", current_week_key)
         
         # Generate report for LAST week
         start, end = get_last_week_range()
@@ -69,8 +70,9 @@ class ReportScheduler:
             start_date=data["start"].strftime("%d.%m.%Y"),
             end_date=data["end"].strftime("%d.%m.%Y"),
         )
+        logger.debug("Email body text: %r", body_text[:200])
         filename = f"verbindungs_report_kw{data['week_number']}.html"
-        
+
         await self._email_service.send_report(
             subject=subject, 
             html_content=html_content,
@@ -79,7 +81,7 @@ class ReportScheduler:
         )
         
         self._metadata_repo.set("last_weekly_report_sent_at", current_week_key)
-        logger.info(f"Weekly report for {current_week_key} sent successfully.")
+        logger.info("Weekly report for %s sent and guard updated.", current_week_key)
 
     def _handle_error(self, exc: Exception) -> None:
-        logger.error(f"Error in ReportScheduler: {exc}")
+        logger.error("Error in ReportScheduler: %s", exc, exc_info=True)

--- a/backend/reporting.py
+++ b/backend/reporting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -8,6 +9,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .database import DeviceLogRepository, OutageRepository
 from .models import DeviceLogEntryRecord, OutageRecord
+
+logger = logging.getLogger(__name__)
 
 
 class ReportingService:
@@ -78,6 +81,7 @@ class ReportingService:
 
     def render_weekly_report(self, data: Dict[str, Any]) -> str:
         """Renders the HTML report using Jinja2."""
+        logger.info("Generated weekly report for KW %s", data.get("week_number"))
         template = self._jinja_env.get_template("weekly_report.html")
         return template.render(**data)
 

--- a/backend/tracker.py
+++ b/backend/tracker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any, Dict
 
@@ -9,6 +10,8 @@ from .database import StatusRepository
 from .device_log_sync import DeviceLogSync
 from .fritzbox_client import FritzboxClient
 from .periodic_runner import PeriodicRunner
+
+logger = logging.getLogger(__name__)
 
 
 class ConnectionTracker:
@@ -46,6 +49,8 @@ class ConnectionTracker:
 
         latest = self._status_repository.latest_event()
         if latest is None or latest.status != status_value:
+            prev = latest.status if latest else "unknown"
+            logger.info("Connection status changed: %s → %s", prev, status_value)
             self._status_repository.record_event(
                 status=status_value,
                 timestamp=timestamp,
@@ -67,12 +72,15 @@ class ConnectionTracker:
         }
 
     async def start(self) -> None:
+        logger.info("ConnectionTracker starting")
         await self._status_poller.start()
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._device_log_sync.run_once)
         await self._device_log_poller.start()
+        logger.info("ConnectionTracker started")
 
     async def stop(self) -> None:
+        logger.info("ConnectionTracker stopping")
         await self._status_poller.stop()
         await self._device_log_poller.stop()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       REPORT_RECIPIENTS: ${REPORT_RECIPIENTS:-}
       REPORT_EMAIL_BODY: ${REPORT_EMAIL_BODY:-}
       REPORT_SCHEDULE_CHECK_INTERVAL_SECONDS: ${REPORT_SCHEDULE_CHECK_INTERVAL_SECONDS:-3600}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
     volumes:
       - /volume1/docker/stoergeler/data:/app/data
 


### PR DESCRIPTION
Set up logging.basicConfig() in main.py with LOG_LEVEL env var (default INFO). Added logger to all operational modules (tracker, fritzbox_client, device_log_sync, database, periodic_runner, reporting) and enhanced report_scheduler/email_service with debug logging for duplicate-email troubleshooting.