### PR TITLE
fix(backend): resolve event loop blocking, unused param, SMTP config,…

### DIFF
--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -50,17 +50,17 @@ class EmailService:
         message.attach(attachment)
 
         try:
-            use_implicit_tls = self._settings.smtp_port == 465
-            
             async with aiosmtplib.SMTP(
                 hostname=self._settings.smtp_server,
                 port=self._settings.smtp_port,
-                use_tls=use_implicit_tls,
+                use_tls=self._settings.smtp_ssl,
             ) as smtp:
+                if not self._settings.smtp_ssl and self._settings.smtp_tls:
+                    await smtp.starttls()
                 if self._settings.smtp_username and self._settings.smtp_password:
                     await smtp.login(
-                        self._settings.smtp_username, 
-                        self._settings.smtp_password
+                        self._settings.smtp_username,
+                        self._settings.smtp_password,
                     )
                 await smtp.send_message(message)
                 

--- a/backend/main.py
+++ b/backend/main.py
@@ -161,14 +161,7 @@ def device_log(
 
 
 @app.get("/outages", response_model=OutageListResponse)
-def outage_windows(
-    limit: Optional[int] = Query(
-        default=300,
-        ge=1,
-        le=1000,
-        description="Optional: Anzahl der Logzeilen, die ausgewertet werden sollen",
-    ),
-) -> OutageListResponse:
+def outage_windows() -> OutageListResponse:
     try:
         stored_outages = outage_repository.list_outages()
     except Exception as exc:  # noqa: BLE001

--- a/backend/report_scheduler.py
+++ b/backend/report_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict
@@ -48,7 +49,11 @@ class ReportScheduler:
         if now.weekday() != 0:  # 0 is Monday
             return
 
-        last_sent_iso = self._metadata_repo.get("last_weekly_report_sent_at")
+        loop = asyncio.get_running_loop()
+
+        last_sent_iso = await loop.run_in_executor(
+            None, self._metadata_repo.get, "last_weekly_report_sent_at"
+        )
         current_week_key = f"{now.year}-W{now.isocalendar()[1]}"
         logger.debug("Report guard check: last_sent=%s, current_week=%s", last_sent_iso, current_week_key)
 
@@ -57,12 +62,16 @@ class ReportScheduler:
             return
 
         logger.info("Preparing weekly report for %s ...", current_week_key)
-        
+
         # Generate report for LAST week
         start, end = get_last_week_range()
-        data = self._reporting_service.get_report_data(start, end)
-        html_content = self._reporting_service.render_weekly_report(data)
-        
+        data = await loop.run_in_executor(
+            None, self._reporting_service.get_report_data, start, end
+        )
+        html_content = await loop.run_in_executor(
+            None, self._reporting_service.render_weekly_report, data
+        )
+
         subject = f"StoerGeler Wochen-Report (KW {data['week_number']})"
         body_template = self._settings.report_email_body.replace("\\n", "\n")
         body_text = body_template.format(
@@ -74,13 +83,15 @@ class ReportScheduler:
         filename = f"verbindungs_report_kw{data['week_number']}.html"
 
         await self._email_service.send_report(
-            subject=subject, 
+            subject=subject,
             html_content=html_content,
             body_text=body_text,
             filename=filename
         )
-        
-        self._metadata_repo.set("last_weekly_report_sent_at", current_week_key)
+
+        await loop.run_in_executor(
+            None, self._metadata_repo.set, "last_weekly_report_sent_at", current_week_key
+        )
         logger.info("Weekly report for %s sent and guard updated.", current_week_key)
 
     def _handle_error(self, exc: Exception) -> None:

--- a/backend/tracker.py
+++ b/backend/tracker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -74,8 +73,6 @@ class ConnectionTracker:
     async def start(self) -> None:
         logger.info("ConnectionTracker starting")
         await self._status_poller.start()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._device_log_sync.run_once)
         await self._device_log_poller.start()
         logger.info("ConnectionTracker started")
 


### PR DESCRIPTION
… and double sync

- Wrap blocking calls in ReportScheduler.check_and_send() with run_in_executor
- Remove unused limit parameter from /api/outages endpoint
- Wire smtp_tls/smtp_ssl config to aiosmtplib (STARTTLS on 587, implicit TLS on 465)
- Remove duplicate device-log sync call on ConnectionTracker startup