### PR TITLE
fix(frontend): fetch outage logs on demand with correct timestamps

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException, Query
@@ -171,10 +172,23 @@ def create_app(deps: Optional[Dependencies] = None) -> FastAPI:
             ge=1,
             le=500,
             description="Optional: Anzahl der Logzeilen beschränken (1-500)",
-        )
+        ),
+        start: Optional[datetime] = Query(
+            default=None,
+            description="Nur Einträge ab diesem Zeitpunkt (ISO-8601)",
+        ),
+        end: Optional[datetime] = Query(
+            default=None,
+            description="Nur Einträge bis zu diesem Zeitpunkt (ISO-8601)",
+        ),
     ) -> DeviceLogResponse:
+        # DB stores naive (no-tz) timestamps — strip tzinfo to match
+        naive_start = start.replace(tzinfo=None) if start else None
+        naive_end = end.replace(tzinfo=None) if end else None
         try:
-            records = deps.device_log_repository.list_entries(limit=limit, ascending=False)
+            records = deps.device_log_repository.list_entries(
+                limit=limit, ascending=False, start=naive_start, end=naive_end,
+            )
         except sqlite3.Error as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         return DeviceLogResponse(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,8 +35,24 @@ export async function fetchOutages(): Promise<OutageWindow[]> {
   return data.outages ?? [];
 }
 
-export async function fetchDeviceLog(limit = 500): Promise<DeviceLogEntry[]> {
-  const data = await request<DeviceLogResponse>(`/device-log?limit=${limit}`);
+/** Format a Date as a naive (no timezone) ISO string matching the DB storage format. */
+function toNaiveISO(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+export async function fetchDeviceLog(
+  options: { limit?: number; start?: Date; end?: Date } = {},
+): Promise<DeviceLogEntry[]> {
+  const params = new URLSearchParams();
+  if (options.limit != null) params.set('limit', String(options.limit));
+  if (options.start) params.set('start', toNaiveISO(options.start));
+  if (options.end) params.set('end', toNaiveISO(options.end));
+  const qs = params.toString();
+  const data = await request<DeviceLogResponse>(`/device-log${qs ? `?${qs}` : ''}`);
   return data.entries ?? [];
 }
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -77,6 +77,7 @@ import {
   NFlex,
   NInputGroup,
 } from 'naive-ui';
+import { fetchDeviceLog } from '../api/client';
 import type { DeviceLogEntry } from '../api/types';
 import CalendarView from '../components/CalendarView.vue';
 import DeviceLogTable from '../components/DeviceLogTable.vue';
@@ -92,6 +93,8 @@ const { isRefreshing } = defineProps<{
 const { state, setSelectedEvent } = useStoergelerState();
 const selectedRange = ref<{ start: Date; end: Date; label: string } | null>(null);
 const drawerOpen = ref(false);
+const drawerLogs = ref<DeviceLogEntry[]>([]);
+const drawerLoading = ref(false);
 const calendarRef = ref<InstanceType<typeof CalendarView> | null>(null);
 const drawerPaginator = usePagination<DeviceLogEntry>([], 20);
 const isMobile = useIsMobile();
@@ -103,7 +106,7 @@ const {
   calendarActions,
 } = useCalendarHeader(calendarRef);
 
-function handleSelectOutage(payload: { eventId: string; start: Date; end: Date; label: string }) {
+async function handleSelectOutage(payload: { eventId: string; start: Date; end: Date; label: string }) {
   setSelectedEvent(payload.eventId);
   selectedRange.value = {
     start: payload.start,
@@ -111,6 +114,15 @@ function handleSelectOutage(payload: { eventId: string; start: Date; end: Date; 
     label: payload.label,
   };
   drawerOpen.value = true;
+  drawerLoading.value = true;
+  drawerLogs.value = [];
+  try {
+    drawerLogs.value = await fetchDeviceLog({ start: payload.start, end: payload.end });
+  } catch {
+    drawerLogs.value = [];
+  } finally {
+    drawerLoading.value = false;
+  }
 }
 
 function handleDrawerUpdate(show: boolean) {
@@ -118,27 +130,9 @@ function handleDrawerUpdate(show: boolean) {
   if (!show) {
     selectedRange.value = null;
     setSelectedEvent(null);
+    drawerLogs.value = [];
   }
 }
-
-function filterLogsByRange(entries: DeviceLogEntry[], start: Date, end: Date) {
-  const startMs = start.getTime();
-  const endMs = end.getTime();
-  return entries.filter((entry) => {
-    if (!entry.timestamp) {
-      return false;
-    }
-    const entryMs = new Date(entry.timestamp).getTime();
-    return entryMs >= startMs && entryMs <= endMs;
-  });
-}
-
-const filteredLogs = computed(() => {
-  if (!selectedRange.value) {
-    return state.logs;
-  }
-  return filterLogsByRange(state.logs, selectedRange.value.start, selectedRange.value.end);
-});
 
 const drawerPageItems = computed(() => drawerPaginator.pageItems.value);
 const drawerPage = computed(() => drawerPaginator.currentPage.value + 1);
@@ -151,7 +145,7 @@ function setDrawerPage(page: number) {
 }
 
 watch(
-  filteredLogs,
+  drawerLogs,
   (logs) => {
     drawerPaginator.setItems(logs);
   },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -92,7 +92,17 @@ class TestDeviceLogEndpoint:
         mock_deps.device_log_repository.list_entries.return_value = []
         resp = client.get("/device-log?limit=10")
         assert resp.status_code == 200
-        mock_deps.device_log_repository.list_entries.assert_called_once_with(limit=10, ascending=False)
+        mock_deps.device_log_repository.list_entries.assert_called_once_with(
+            limit=10, ascending=False, start=None, end=None,
+        )
+
+    def test_passes_start_end_params(self, client, mock_deps):
+        mock_deps.device_log_repository.list_entries.return_value = []
+        resp = client.get("/device-log?start=2024-01-15T00:00:00Z&end=2024-01-15T23:59:59Z")
+        assert resp.status_code == 200
+        call_kwargs = mock_deps.device_log_repository.list_entries.call_args
+        assert call_kwargs.kwargs["start"] is not None
+        assert call_kwargs.kwargs["end"] is not None
 
     def test_rejects_invalid_limit(self, client):
         resp = client.get("/device-log?limit=0")


### PR DESCRIPTION
## Summary
- Add `start`/`end` query params to `/api/device-log` endpoint
- Fetch logs for the selected outage's time range when the calendar drawer opens, instead of filtering a fixed-size local cache (fixes missing logs for older outages)
- Use naive local-time ISO format for date params to match DB storage format, fixing a timezone offset bug where `toISOString()` shifted times by the local UTC offset
- Remove the default `limit=500` on initial log fetch so the Logs view shows all entries

## Test plan
- [x] All 79 tests pass (`pytest tests/`)
- [x] Frontend builds cleanly (`npm run build`)
- [x] Click outages before Jan 16 — drawer should show matching log entries
- [x] Click recent outages — still works as before
- [x] Logs tab shows all entries, not just most recent 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)