### PR TITLE
feat(backend): add POST /outages/recalculate endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ REPORT_SCHEDULE_CHECK_INTERVAL_SECONDS=3600
 - `GET /api/connection-check` - Live TR-064 connection check
 - `GET /api/device-log?limit=500` - Device log entries (descending)
 - `GET /api/outages` - Calculated outage windows
+- `POST /api/outages/recalculate` - Rebuild calculated outages from stored device logs (idempotent, keeps manual outages, no Fritzbox call)
 - `GET /api/version` - Backend version info
 
 ## Release Process

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -25,6 +25,7 @@ from .email_service import EmailService
 from .fritzbox_client import FritzBoxCredentials, FritzboxClient
 from .outage_calculator import OutageCalculator
 from .outage_config import OutageKeywords
+from .recalculate_outages import recalculate_outages
 from .report_scheduler import ReportScheduler
 from .reporting import ReportingService, get_current_week_range, get_last_week_range
 from .schemas import (
@@ -34,6 +35,7 @@ from .schemas import (
     OutageCreate,
     OutageCreateResponse,
     OutageListResponse,
+    OutageRecalculateResponse,
     OutageWindow,
     StatusResponse,
 )
@@ -52,6 +54,7 @@ class Dependencies:
     reporting_service: ReportingService
     email_service: EmailService
     report_scheduler: ReportScheduler
+    outage_calculator: Optional[OutageCalculator] = None
 
 
 def _build_default_dependencies(settings: Any) -> Dependencies:
@@ -113,6 +116,7 @@ def _build_default_dependencies(settings: Any) -> Dependencies:
         reporting_service=reporting_service,
         email_service=email_service,
         report_scheduler=report_scheduler,
+        outage_calculator=outage_calculator,
     )
 
 
@@ -244,6 +248,25 @@ def create_app(deps: Optional[Dependencies] = None) -> FastAPI:
                 status=body.status,
             ),
         )
+
+    @app.post("/outages/recalculate", response_model=OutageRecalculateResponse)
+    def recalculate() -> OutageRecalculateResponse:
+        """Rebuild calculated outages from stored device logs.
+
+        Forces the recalculation that normally runs on each device-log sync,
+        without contacting the Fritzbox. Idempotent; manual outages are kept.
+        """
+        if deps.outage_calculator is None:
+            raise HTTPException(status_code=503, detail="Outage calculator not available")
+        try:
+            count = recalculate_outages(
+                device_log_repository=deps.device_log_repository,
+                outage_repository=deps.outage_repository,
+                outage_calculator=deps.outage_calculator,
+            )
+        except sqlite3.Error as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return OutageRecalculateResponse(outages=count)
 
     @app.get("/connection-check", response_model=ConnectivityStatus)
     def connection_check() -> ConnectivityStatus:

--- a/backend/recalculate_outages.py
+++ b/backend/recalculate_outages.py
@@ -27,26 +27,17 @@ from .outage_config import OutageKeywords
 logger = logging.getLogger(__name__)
 
 
-def recalculate_outages() -> int:
+def recalculate_outages(
+    device_log_repository: DeviceLogRepository,
+    outage_repository: OutageRepository,
+    outage_calculator: OutageCalculator,
+) -> int:
     """Rebuild the calculated outages from all stored device log entries.
 
-    Returns the number of outages written.
+    Idempotent and only touches calculated outages: ``replace_outages`` deletes
+    ``source = 'calculated'`` rows and re-inserts them, leaving manually-created
+    outages intact. Returns the number of outages written.
     """
-    db_context = DatabaseContext(settings.database_path)
-    db_context.init_schema()
-
-    device_log_repository = DeviceLogRepository(db_context)
-    outage_repository = OutageRepository(db_context)
-    outage_calculator = OutageCalculator(
-        cfg=OutageKeywords(
-            planned_keywords=settings.outage_planned_keywords,
-            ipv4_disconnect_keywords=settings.outage_ipv4_disconnect_keywords,
-            ipv4_connect_keywords=settings.outage_ipv4_connect_keywords,
-            ipv6_disconnect_keywords=settings.outage_ipv6_disconnect_keywords,
-            ipv6_connect_keywords=settings.outage_ipv6_connect_keywords,
-        )
-    )
-
     before = len(outage_repository.list_outages())
     entries = device_log_repository.list_entries()
     outages = outage_calculator.calculate(entries)
@@ -69,7 +60,23 @@ def main() -> None:
         level=getattr(logging, settings.log_level, logging.INFO),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    recalculate_outages()
+
+    db_context = DatabaseContext(settings.database_path)
+    db_context.init_schema()
+    outage_calculator = OutageCalculator(
+        cfg=OutageKeywords(
+            planned_keywords=settings.outage_planned_keywords,
+            ipv4_disconnect_keywords=settings.outage_ipv4_disconnect_keywords,
+            ipv4_connect_keywords=settings.outage_ipv4_connect_keywords,
+            ipv6_disconnect_keywords=settings.outage_ipv6_disconnect_keywords,
+            ipv6_connect_keywords=settings.outage_ipv6_connect_keywords,
+        )
+    )
+    recalculate_outages(
+        device_log_repository=DeviceLogRepository(db_context),
+        outage_repository=OutageRepository(db_context),
+        outage_calculator=outage_calculator,
+    )
 
 
 if __name__ == "__main__":

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -59,6 +59,10 @@ class OutageCreateResponse(BaseModel):
     outage: OutageWindow
 
 
+class OutageRecalculateResponse(BaseModel):
+    outages: int = Field(description="Anzahl der neu berechneten Störungen")
+
+
 class ConnectivityStatus(BaseModel):
     connected: bool = Field(description="Gibt an, ob laut TR-064 derzeit eine Verbindung besteht")
     external_ip: Optional[str] = Field(default=None, description="Vom Router gemeldete externe IPv4")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,6 +156,23 @@ class TestCreateOutageEndpoint:
         assert data["outage"]["duration_seconds"] is None
 
 
+class TestRecalculateEndpoint:
+    def test_recalculates_and_returns_count(self, client, mock_deps):
+        mock_deps.outage_calculator = MagicMock()
+        mock_deps.outage_repository.list_outages.return_value = []
+        mock_deps.device_log_repository.list_entries.return_value = []
+        mock_deps.outage_calculator.calculate.return_value = [{}, {}, {}]
+        resp = client.post("/outages/recalculate")
+        assert resp.status_code == 200
+        assert resp.json()["outages"] == 3
+        mock_deps.outage_repository.replace_outages.assert_called_once()
+
+    def test_returns_503_without_calculator(self, client, mock_deps):
+        # mock_deps leaves outage_calculator as its default (None)
+        resp = client.post("/outages/recalculate")
+        assert resp.status_code == 503
+
+
 class TestConnectionCheckEndpoint:
     def test_returns_connectivity(self, client, mock_deps):
         mock_deps.tracker.check_connection.return_value = {


### PR DESCRIPTION
## Summary

Adds an on-demand recalculation endpoint as a follow-up to #49 (which merged the IPv4/IPv6 outage merge fix and the frontend log-range fix).

**`POST /api/outages/recalculate`** rebuilds the calculated outages from stored device logs and returns `{"outages": <count>}`. Useful to correct historical data immediately after a deploy (e.g. via Swagger at `/docs`) instead of waiting for the next device-log sync.

- Idempotent; only touches `source='calculated'` rows, so manually-created outages are preserved.
- No Fritzbox round-trip — reads only from the DB.
- Shares logic with the existing `python -m backend.recalculate_outages` CLI: `recalculate_outages()` was refactored to accept the wired repositories + calculator, and the `OutageCalculator` is now stored on `Dependencies` (defaulted to `None`, so existing wiring/tests are unaffected; the endpoint returns 503 if it is absent).

## Verification
- Backend suite: 83 passing (added 2 endpoint tests: success returns the count and calls `replace_outages`; 503 when the calculator is missing).
- End-to-end via the endpoint against a copy of the real bug DB: 345 → 304 outages, 06-03 night 8 → 4, the 1 manual outage preserved, response `{"outages": 303}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)